### PR TITLE
Linked values do not work for multiselection list custom fields

### DIFF
--- a/pages/bug_page_custom_field_links.php
+++ b/pages/bug_page_custom_field_links.php
@@ -93,9 +93,9 @@ var LinkedCustomFieldsUtil = {
 	},
 	findCustomFieldByFieldId: function(fieldId) {
 
-		var fieldRef = jQuery('[name=custom_field_' + fieldId  +']');
+		var fieldRef = jQuery('[name="custom_field_' + fieldId  +'"]');
 		if ( fieldRef.length == 0 ) {
-			fieldRef = jQuery('[name=custom_field_' + fieldId  +'[]]');
+			fieldRef = jQuery('[name="custom_field_' + fieldId  +'[]"]');
 		}
 
 		return fieldRef;


### PR DESCRIPTION
Set the custom fields to display when reporting issues.
Set at least one of them to be a multiselection list.
Report an issue -> doesn't work.

jquery('[attribute=value]') should have quotes around the value
PR to fix.