### PR TITLE
Fix issue #10 - problem with certain characters in field values

### DIFF
--- a/LinkedCustomFields.API.php
+++ b/LinkedCustomFields.API.php
@@ -109,7 +109,7 @@ class JavascriptUtils {
 		$t_field_values_js = '[ ';
 
 		foreach( $p_array as $t_custom_field_value ) {
-			$t_field_values_js .= '"'.string_attribute( $t_custom_field_value ).'" ,';
+			$t_field_values_js .= '"'.addslashes( $t_custom_field_value ).'" ,';
 		}
 
 		$t_field_values_js = rtrim( $t_field_values_js, ',' );

--- a/LinkedCustomFields.API.php
+++ b/LinkedCustomFields.API.php
@@ -105,17 +105,7 @@ class JavascriptUtils {
 	const LOG_ERROR = 4;
 
 	static function toJSArray( $p_array ) {
-
-		$t_field_values_js = '[ ';
-
-		foreach( $p_array as $t_custom_field_value ) {
-			$t_field_values_js .= '"'.addslashes( $t_custom_field_value ).'" ,';
-		}
-
-		$t_field_values_js = rtrim( $t_field_values_js, ',' );
-		$t_field_values_js .= ']';
-
-		return $t_field_values_js;
+		return json_encode($p_array);
 	}
 
 	static function consoleLog( $p_message, $p_level = self::LOG_INFO ) {


### PR DESCRIPTION
Use one or more of &"<> in the value of  a target field.
Report an issue.
The field values are not displayed properly in the select list.
Click on the Submit Issue button.
There is an error saying invalid value for field.
Fixes issue #10 

